### PR TITLE
use unique id for CohortWithdawal

### DIFF
--- a/src/CohortContract.ts
+++ b/src/CohortContract.ts
@@ -30,7 +30,7 @@ ponder.on("CohortContract:UpdateBuilder", async ({ event, context }) => {
 
 ponder.on("CohortContract:Withdraw", async ({ event, context }) => {
   await context.db.insert(cohortWithdrawal).values({
-    id: `${event.args.to}-${event.log.address}-${event.block.number}`,
+    id: event.log.id,
     builder: event.args.to,
     amount: parseFloat(formatEther(event.args.amount)),
     cohortContractAddress: event.log.address,


### PR DESCRIPTION
### Description: 

There might be a case where Withdrawal events will be emitted in the same block itself.  

Example: https://etherscan.io/address/0x24f0aec2e06c25c60f54e37870ca555b2d9ba609#events

To handle this we used `event.log.id` => Globally unique identifier for this log (`${blockHash}-${logIndex}`) ([ponder docs](https://arc.net/l/quote/erjffjby))

We can't use serial id/autoincrementing id since it's not supported by ponder. Checkout [this discussion](https://github.com/ponder-sh/ponder/discussions/1270) 

