### PR TITLE
Add endBlock to Optimism

### DIFF
--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -165,6 +165,7 @@ export default createConfig({
         optimism: {
           address: optimismCohorts,
           startBlock: 101114639,
+          endBlock: 151240163,          ,
         },
       },
     },
@@ -180,6 +181,7 @@ export default createConfig({
         optimism: {
           // 2024-02-14 block, we don't need to index before that because the cohort balance is updated on withdrawal too
           startBlock: 131978309,
+          endBlock: 151240163,
           interval: 60 / 2, // Every hour
         },
       },


### PR DESCRIPTION
So we stop indexing new events for contracts deployed on Optimism.

Mainnet contracts share the same endBlock.

We can change the config to have a different contract name for the mainnet contract that is still used, but since Optimism is the network that is using more RPC requests, I think it would not affect the RPC cost too much.